### PR TITLE
Fix session pickling

### DIFF
--- a/plugin.video.curiositystream/resources/lib/curiositystream.py
+++ b/plugin.video.curiositystream/resources/lib/curiositystream.py
@@ -6,6 +6,7 @@ from math import floor
 import requests
 import xbmc
 import xbmcgui
+import traceback
 
 
 class CSAuthFailed(Exception):
@@ -116,9 +117,12 @@ class CuriosityStream(object):
                     session["cookies"]
                 )
                 self._session.headers.update(session["headers"])
-        except IOError:
-            # unable to read the file
+        except FileNotFoundError:
+            # session just didn't exist yet
             pass
+        except:
+            # other errors are potentially a problem, so log a warning.
+            xbmc.log(traceback.format_exc(), xbmc.LOGWARNING)
 
     def authenticate(self, force=False):
         if (

--- a/plugin.video.curiositystream/resources/lib/curiositystream.py
+++ b/plugin.video.curiositystream/resources/lib/curiositystream.py
@@ -97,7 +97,7 @@ class CuriosityStream(object):
         self._load_session()
 
     def _save_session(self):
-        with open(self._session_file, "w") as fd:
+        with open(self._session_file, "wb") as fd:
             pickle.dump(
                 {
                     "headers": self._session.headers,

--- a/plugin.video.curiositystream/resources/lib/router.py
+++ b/plugin.video.curiositystream/resources/lib/router.py
@@ -9,6 +9,7 @@ else:
     from urlparse import parse_qsl
 
 import xbmcgui
+import xbmcvfs
 import xbmcplugin
 import xbmcaddon
 import xbmc
@@ -44,7 +45,7 @@ class Router(object):
         self._cs_api = cs.CuriosityStream(
             username=xbmcaddon.Addon().getSetting("username"),
             password=xbmcaddon.Addon().getSetting("password"),
-            profile_path=xbmc.translatePath(xbmcaddon.Addon().getAddonInfo("profile")),
+            profile_path=xbmcvfs.translatePath(xbmcaddon.Addon().getAddonInfo("profile")),
             auth_context=authorize_context,
         )
         # ensure the user is logged in by calling my_account api

--- a/plugin.video.curiositystream/resources/lib/router.py
+++ b/plugin.video.curiositystream/resources/lib/router.py
@@ -13,6 +13,7 @@ import xbmcvfs
 import xbmcplugin
 import xbmcaddon
 import xbmc
+import traceback
 from resources.lib import curiositystream as cs
 
 tr = xbmcaddon.Addon().getLocalizedString
@@ -35,6 +36,7 @@ def authorize_context():
         xbmcgui.Dialog().ok(tr(30002), e.error_message)
     except Exception as e:
         dialog.close()
+        xbmc.log(traceback.format_exc(), xbmc.LOGERROR)
         xbmcgui.Dialog().ok(tr(30002), "Internal error: {}".format(str(e)))
 
 


### PR DESCRIPTION
This PR fixes session pickling. The file to dump the pickled session to must be opened in binary mode, or it fails with an exception: `TypeError: must be str, not bytes`. This probably broke with python 3. 

Additionally, this PR improves error handling a bit: when unexpected errors occur during authentication, the full exception traceback is added to the event log. Similarly, when unpickling fails other than with a FileNotFoundError, a traceback is logged as warning and an empty session is used.

Finally, it replaces the use of the deprecated `xbmc.translatePath()` with `xbmcvfs.translatePath()`.